### PR TITLE
Set owner group to each user primary group

### DIFF
--- a/molecule/common/prepare.yml
+++ b/molecule/common/prepare.yml
@@ -9,6 +9,11 @@
       ansible.builtin.set_fact:
         sudo_group: "{{ 'sudo' if ansible_os_family == 'Debian' else 'wheel' }}"
 
+    - name: Create group {{ sudo_group }}
+      ansible.builtin.group:
+        name: "{{ sudo_group }}"
+        state: present
+
     - name: Enable passwordless sudo
       ansible.builtin.lineinfile:
         path: /etc/sudoers
@@ -21,7 +26,7 @@
       ansible.builtin.user:
         state: present
         name: "{{ item }}"
-        groups: "{{ sudo_group }}"
+        group: "{{ sudo_group }}"
         shell: /bin/bash
         append: true
       loop: "{{ nu_users }}"

--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -71,7 +71,6 @@
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "/tmp/{{ item.name }}"
-    owner: "{{ ansible_user_id }}"
     mode: "0750"
   loop: "{{ config_urls }}"
   loop_control:
@@ -115,7 +114,7 @@
     state: present
     line: "{{ nushell_binary_path }}/nu -l"
     owner: "{{ item.user }}"
-    group: "{{ user_groups[ansible_facts.getent_passwd[item.item[0].user][2]] if ansible_system == 'Linux' else 'staff' }}"
+    group: "{{ user_groups[ansible_facts.getent_passwd[item.user][2]] if ansible_system == 'Linux' else 'staff' }}"
     mode: "0750"
     create: true
   when: add_to_profile|bool

--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -5,11 +5,28 @@
     - name: Query homedirs (Linux)
       ansible.builtin.getent:
         database: passwd
-      register: getent
 
-    - name: Set homedirs as fact (Linux)
+    - name: Query primary groups (Linux)
+      ansible.builtin.getent:
+        database: group
+        split: ':'
+
+    - name: Set facts (Linux)
       ansible.builtin.set_fact:
-        home_dirs: "{{ nu_users | zip(nu_users | map('extract', getent.ansible_facts.getent_passwd, 4)) | community.general.dict | dict2items(key_name='user', value_name='homedir') }}"
+        home_dirs: >
+          {{
+            nu_users
+            | zip(nu_users | map('extract', ansible_facts.getent_passwd, 4))
+            | community.general.dict
+            | dict2items(key_name='user', value_name='homedir')
+          }}
+        user_groups: >
+          {{
+            ansible_facts.getent_group.keys()
+            | zip(ansible_facts.getent_group | dict2items | map(attribute='value.1'))
+            | map('reverse')
+            | community.general.dict
+          }}
 
 - name: Gather users home_dirs (macOS)
   when: ansible_system == 'Darwin'
@@ -21,7 +38,7 @@
       register: dscl
       changed_when: false
 
-    - name: Set homedirs as fact (macOS)
+    - name: Set facts (macOS)
       ansible.builtin.set_fact:
         home_dirs: "{{ nu_users | zip(dscl.results | map(attribute='stdout')) | community.general.dict | dict2items(key_name='user', value_name='homedir') }}"
 
@@ -44,7 +61,7 @@
     dest: "{{ item.item[0].homedir }}/{{ nushell_config_path }}/"
     mode: "0750"
     owner: "{{ item.item[0].user }}"
-    #group: "{{ item.user if ansible_system == 'Linux' else 'staff' }}"
+    group: "{{ user_groups[ansible_facts.getent_passwd[item.item[0].user][2]] if ansible_system == 'Linux' else 'staff' }}"
   loop: "{{ missing_configs }}"
   loop_control:
     label: "{{ item.invocation.module_args.path }}"
@@ -55,7 +72,6 @@
     url: "{{ item.url }}"
     dest: "/tmp/{{ item.name }}"
     owner: "{{ ansible_user_id }}"
-    #group: "{{ ansible_user_id if ansible_system == 'Linux' else 'wheel' }}"
     mode: "0750"
   loop: "{{ config_urls }}"
   loop_control:
@@ -71,7 +87,7 @@
     src: "/tmp/{{ item.invocation.module_args.path | basename }}"
     dest: "{{ item.item[0].homedir }}/{{ nushell_config_path }}/"
     owner: "{{ item.item[0].user }}"
-    #group: "{{ item.item[0].user if ansible_system == 'Linux' else 'staff' }}"
+    group: "{{ user_groups[ansible_facts.getent_passwd[item.item[0].user][2]] if ansible_system == 'Linux' else 'staff' }}"
     mode: "0750"
     remote_src: true
   loop: "{{ missing_configs }}"
@@ -99,7 +115,7 @@
     state: present
     line: "{{ nushell_binary_path }}/nu -l"
     owner: "{{ item.user }}"
-    #group: "{{ item.user if ansible_system == 'Linux' else 'staff' }}"
+    group: "{{ user_groups[ansible_facts.getent_passwd[item.item[0].user][2]] if ansible_system == 'Linux' else 'staff' }}"
     mode: "0750"
     create: true
   when: add_to_profile|bool

--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -44,7 +44,7 @@
     dest: "{{ item.item[0].homedir }}/{{ nushell_config_path }}/"
     mode: "0750"
     owner: "{{ item.item[0].user }}"
-    group: "{{ item.user if ansible_system == 'Linux' else 'staff' }}"
+    #group: "{{ item.user if ansible_system == 'Linux' else 'staff' }}"
   loop: "{{ missing_configs }}"
   loop_control:
     label: "{{ item.invocation.module_args.path }}"
@@ -54,7 +54,7 @@
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "/tmp/{{ item.name }}"
-    #owner: "{{ ansible_user_id }}"
+    owner: "{{ ansible_user_id }}"
     #group: "{{ ansible_user_id if ansible_system == 'Linux' else 'wheel' }}"
     mode: "0750"
   loop: "{{ config_urls }}"
@@ -71,7 +71,7 @@
     src: "/tmp/{{ item.invocation.module_args.path | basename }}"
     dest: "{{ item.item[0].homedir }}/{{ nushell_config_path }}/"
     owner: "{{ item.item[0].user }}"
-    group: "{{ item.item[0].user if ansible_system == 'Linux' else 'staff' }}"
+    #group: "{{ item.item[0].user if ansible_system == 'Linux' else 'staff' }}"
     mode: "0750"
     remote_src: true
   loop: "{{ missing_configs }}"
@@ -99,7 +99,7 @@
     state: present
     line: "{{ nushell_binary_path }}/nu -l"
     owner: "{{ item.user }}"
-    group: "{{ item.user if ansible_system == 'Linux' else 'staff' }}"
+    #group: "{{ item.user if ansible_system == 'Linux' else 'staff' }}"
     mode: "0750"
     create: true
   when: add_to_profile|bool


### PR DESCRIPTION
Previously the role assumed that the group owner for every file was the same as the user name which breaks on systems where users have a primary group different from their username